### PR TITLE
Redirect user to redirect url when an error occurs

### DIFF
--- a/app/code/community/TIG/Buckaroo3Extended/Model/Response/Abstract.php
+++ b/app/code/community/TIG/Buckaroo3Extended/Model/Response/Abstract.php
@@ -322,6 +322,7 @@ class TIG_Buckaroo3Extended_Model_Response_Abstract extends TIG_Buckaroo3Extende
 
         $this->sendDebugEmail();
         header('Location:' . $returnUrl);
+        exit;
     }
 
     protected function _rejected($message = '')


### PR DESCRIPTION
Only setting the header "Location: REDIRECT_URL" is not enough. An exit-statement is required to actually redirect the user to the REDIRECT_URL.

### Make sure you are using the *latest* version: https://tig.nl/buckaroo-magento-extensies/
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG Buckaroo Magento extension.

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description of your *issue*, suggested solution and other information
When placing an order it is possible that the used SoapClient cannot load the WSDL. When this occurs, error handling kicks in which cancels the current order, restores the previous quote and should result in the user being redirected to the checkout. Instead, the user will see a blank page, after which the user is able to refresh the page and perform a payment on the cancelled order. These orders will remain stuck in the "Cancelled" state, even though the user has been able to perform a payment. 

In PHP, it is recommended to add an exit-statement after setting a location-header. This is done in most response handling methods, but is forgotten in the _error handling method.

### TIG supportdesk

On Github we will respond in English even when the question was asked in Dutch.
