### PR TITLE
Add setting so creditmemo mail will be sent

### DIFF
--- a/app/code/community/TIG/Buckaroo3Extended/Model/Refund/Creditmemo.php
+++ b/app/code/community/TIG/Buckaroo3Extended/Model/Refund/Creditmemo.php
@@ -170,6 +170,10 @@ class TIG_Buckaroo3Extended_Model_Refund_Creditmemo extends TIG_Buckaroo3Extende
             'comment_text'    => '',
         );
 
+        if (Mage::getStoreConfig('buckaroo/buckaroo3extended_advanced/creditmemo_mail', $this->_order->getStoreId())) {
+            $data['send_email'] = true;
+        }
+
         $totalToRefund = $totalAmount + $this->_order->getBaseTotalRefunded();
         if ($totalToRefund == $this->_order->getBaseGrandTotal()) {
 

--- a/app/code/community/TIG/Buckaroo3Extended/etc/system.xml
+++ b/app/code/community/TIG/Buckaroo3Extended/etc/system.xml
@@ -7149,6 +7149,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </auto_invoice>
+                        <creditmemo_mail translate="label comment">
+                            <label>Send transactional credit memo email</label>
+                            <comment>Send a mail after credit memo is created.</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>buckaroo3extended/sources_yesno</source_model>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </creditmemo_mail>
                         <success_redirect translate="label comment">
                             <label>Redirect url after 'Success'</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
### Submitting issues trough Github
## Please follow the guide below

- You will be asked some questions and requested to provide some information, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *issue* (like this: `[x]`)
- Use the *Preview* tab to see what your issue will actually look like

---

### Make sure you are using the *latest* version: https://tig.nl/buckaroo-magento-extensies/
Issues with outdated version will be rejected.
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG Buckaroo Magento extension.

---

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [x] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description of your *issue*, suggested solution and other information

Credit memo emails were not being sent. Added an option so this can be configured and the email for the credit memo will be sent when a refund is created in buckaroo.


### TIG supportdesk

On Github we will respond in English even when the question was asked in Dutch.
