### PR TITLE
Fix array to string conversion in Capayable PaymentMethod

### DIFF
--- a/app/code/community/TIG/Buckaroo3Extended/Model/PaymentMethods/Capayable/PaymentMethod.php
+++ b/app/code/community/TIG/Buckaroo3Extended/Model/PaymentMethods/Capayable/PaymentMethod.php
@@ -73,7 +73,8 @@ class TIG_Buckaroo3Extended_Model_PaymentMethods_Capayable_PaymentMethod extends
         // exclude certain keys that are always different
         $excludeKeys = array(
             'entity_id', 'entity_type_id', 'parent_id', 'created_at', 'updated_at', 'customer_address_id',
-            'quote_address_id', 'address_id', 'region_id', 'customer_id', 'address_type', 'applied_taxes'
+            'quote_address_id', 'address_id', 'region_id', 'customer_id', 'address_type', 'applied_taxes',
+            'cached_items_all', 'cached_items_nominal', 'cached_items_nonnominal'
         );
 
         //get both the order-addresses


### PR DESCRIPTION
### Make sure you are using the *latest* version
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG Buckaroo Magento extension.

---

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG Buckaroo Magento extension)

---

### Description of your *issue*, suggested solution and other information

When an address contains any of the items `['cached_items_all', 'cached_items_nominal', 'cached_items_nonnominal']`, the Capayable payment method will throw an 'array to string conversion' error. The error occurs in `TIG_Buckaroo3Extended_Model_PaymentMethods_Capayable_PaymentMethod::isShippingDifferent()`, line 88. 

